### PR TITLE
feat: add cooking progress bar

### DIFF
--- a/components/cooking/CookingProgressBar.tsx
+++ b/components/cooking/CookingProgressBar.tsx
@@ -1,0 +1,44 @@
+'use client'
+
+interface CookingProgressBarProps {
+  total: number
+  done: number
+}
+
+export default function CookingProgressBar({ total, done }: CookingProgressBarProps) {
+  const percent = total > 0 ? Math.round((done / total) * 100) : 0
+  const isComplete = percent === 100
+
+  return (
+    <div className="mb-4">
+      <div className="flex items-center justify-between mb-1.5">
+        <span className="text-xs font-medium text-slate-500 dark:text-text-secondary-dark">
+          Postęp gotowania
+        </span>
+        <span
+          className={`text-xs font-bold transition-colors ${
+            isComplete ? 'text-emerald-600 dark:text-emerald-400' : 'text-primary'
+          }`}
+        >
+          {percent}%
+        </span>
+      </div>
+
+      <div className="h-2 w-full rounded-full bg-slate-200 dark:bg-slate-700 overflow-hidden">
+        <div
+          className={`h-full rounded-full transition-all duration-500 ease-out ${
+            isComplete ? 'bg-emerald-500 dark:bg-emerald-400' : 'bg-primary'
+          }`}
+          style={{ width: `${percent}%` }}
+        />
+      </div>
+
+      {isComplete && (
+        <div className="mt-2 flex items-center gap-1.5 text-emerald-600 dark:text-emerald-400 animate-pulse">
+          <span className="material-symbols-outlined text-[16px]">celebration</span>
+          <span className="text-xs font-medium">Danie gotowe! Smacznego 🎉</span>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/cooking/CookingView.tsx
+++ b/components/cooking/CookingView.tsx
@@ -5,6 +5,7 @@ import type { Meal } from '@/types'
 import { scaleIngredient, scaleNutrition } from '@/lib/scaling'
 import { parseRecipe, enrichStepsStructured } from '@/lib/recipe'
 import RecipeSteps from '@/components/cooking/RecipeSteps'
+import CookingProgressBar from '@/components/cooking/CookingProgressBar'
 
 interface CookingViewProps {
   meal: Meal
@@ -161,6 +162,10 @@ export default function CookingView({ meal, people, scaleFactor }: CookingViewPr
               </span>
               Przepis
             </h2>
+            <CookingProgressBar
+              total={structuredSteps.length}
+              done={structuredSteps.filter((_, i) => checkedSteps[i]).length}
+            />
             <RecipeSteps
               steps={structuredSteps}
               checkedSteps={checkedSteps}


### PR DESCRIPTION
## Summary

Adds a visual progress bar to the cooking view that tracks how many recipe steps have been completed.

## Changes

- **New component**: `components/cooking/CookingProgressBar.tsx` — displays a progress bar with percentage label, animates smoothly as steps are checked off, and shows a celebration message with animation when all steps are done (100%)
- **Updated**: `components/cooking/CookingView.tsx` — imports and renders `CookingProgressBar` above the recipe steps, passing `total` (total steps) and `done` (checked steps count)

## Behaviour

1. Progress bar appears above the list of cooking steps
2. Progress updates live as checkboxes are toggled
3. At 100%, the bar turns emerald green and a pulsing 🎉 completion message appears
4. Full dark mode support via Tailwind dark: variants

Fixes #4