### PR TITLE
feat: add Cloudflare Web Analytics integration

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next'
+import Script from 'next/script'
 import './globals.css'
 import AppShell from '@/components/AppShell'
 
@@ -17,6 +18,11 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang="pl">
       <body>
         <AppShell>{children}</AppShell>
+        <Script
+          src="https://static.cloudflareinsights.com/beacon.min.js"
+          data-cf-beacon='{"token": "CLOUDFLARE_ANALYTICS_TOKEN"}'
+          strategy="afterInteractive"
+        />
       </body>
     </html>
   )


### PR DESCRIPTION
## Summary

Adds Cloudflare Web Analytics beacon script to the root layout for privacy-friendly usage tracking (GDPR compliant).

## Changes

- `app/layout.tsx`: Added `next/script` import and Cloudflare Web Analytics beacon script with `strategy="afterInteractive"`
- Uses a placeholder token (`CLOUDFLARE_ANALYTICS_TOKEN`) — the actual token should be configured in the Cloudflare dashboard and set here

## How it works

The beacon script loads after the page becomes interactive (non-blocking), collects anonymous usage statistics via Cloudflare Web Analytics, and respects user privacy without requiring cookies.

Closes #6