### PR TITLE
refactor: add 1/4 and 1/3 fraction support to scaling logic

### DIFF
--- a/__tests__/lib/scaling.test.ts
+++ b/__tests__/lib/scaling.test.ts
@@ -4,6 +4,7 @@ import {
   scaleNutrition,
   computeScaleFactor,
   computePersonRatio,
+  snapToNiceFraction,
   BASE_KCAL_PER_PERSON,
 } from '@/lib/scaling'
 import type { Ingredient, PersonSettings } from '@/types'
@@ -130,6 +131,78 @@ describe('scaling', () => {
   describe('BASE_KCAL_PER_PERSON constant', () => {
     it('is 2000', () => {
       expect(BASE_KCAL_PER_PERSON).toBe(2000)
+    })
+  })
+
+  describe('snapToNiceFraction', () => {
+    it('snaps 0.25 to 1/4', () => {
+      expect(snapToNiceFraction(0.25)).toBeCloseTo(0.25)
+    })
+
+    it('snaps 0.1 to 1/4 (minimum value)', () => {
+      expect(snapToNiceFraction(0.1)).toBeCloseTo(0.25)
+    })
+
+    it('snaps 0.33 to 1/3', () => {
+      expect(snapToNiceFraction(1 / 3)).toBeCloseTo(1 / 3)
+    })
+
+    it('snaps 0.5 to 1/2', () => {
+      expect(snapToNiceFraction(0.5)).toBeCloseTo(0.5)
+    })
+
+    it('snaps 0.67 to 2/3', () => {
+      expect(snapToNiceFraction(2 / 3)).toBeCloseTo(2 / 3)
+    })
+
+    it('snaps 0.75 to 3/4', () => {
+      expect(snapToNiceFraction(0.75)).toBeCloseTo(0.75)
+    })
+
+    it('snaps 1.0 to 1', () => {
+      expect(snapToNiceFraction(1.0)).toBe(1)
+    })
+
+    it('snaps values > 2 to 0.5 increments', () => {
+      expect(snapToNiceFraction(2.3)).toBeCloseTo(2.5)
+      expect(snapToNiceFraction(3.1)).toBeCloseTo(3)
+    })
+  })
+
+  describe('fraction scaling for spoon units', () => {
+    it('scales łyżeczka to 1/4 when result is small', () => {
+      // 1 łyżeczka * 0.25 = 0.25 → "1/4 łyżeczki"
+      const ing: Ingredient = { name: 'Sól', amount: '1 łyżeczka' }
+      const result = scaleIngredient(ing, 0.25)
+      expect(result.amount).toBe('1/4 łyżeczki')
+    })
+
+    it('scales łyżeczka to 1/3 when result is ~1/3', () => {
+      // 1 łyżeczka * (1/3) ≈ 0.333 → "1/3 łyżeczki"
+      const ing: Ingredient = { name: 'Pieprz', amount: '1 łyżeczka' }
+      const result = scaleIngredient(ing, 1 / 3)
+      expect(result.amount).toBe('1/3 łyżeczki')
+    })
+
+    it('scales łyżka to 1/2 when result is 0.5', () => {
+      // 1 łyżka * 0.5 = 0.5 → "1/2 łyżki"
+      const ing: Ingredient = { name: 'Oliwa', amount: '1 łyżka' }
+      const result = scaleIngredient(ing, 0.5)
+      expect(result.amount).toBe('1/2 łyżki')
+    })
+
+    it('scales łyżeczki to 2/3 when result is ~2/3', () => {
+      // 2 łyżeczki * (1/3) ≈ 0.667 → "2/3 łyżeczki"
+      const ing: Ingredient = { name: 'Kumin', amount: '2 łyżeczki' }
+      const result = scaleIngredient(ing, 1 / 3)
+      expect(result.amount).toBe('2/3 łyżeczki')
+    })
+
+    it('scales łyżka to 3/4 when result is 0.75', () => {
+      // 3 łyżki * 0.25 = 0.75 → "3/4 łyżki"
+      const ing: Ingredient = { name: 'Sos sojowy', amount: '3 łyżki' }
+      const result = scaleIngredient(ing, 0.25)
+      expect(result.amount).toBe('3/4 łyżki')
     })
   })
 })

--- a/lib/amounts.ts
+++ b/lib/amounts.ts
@@ -135,6 +135,18 @@ export function parseAmount(amount: string): ParsedAmount | null {
 }
 
 export function formatNumber(n: number): string {
+  // Format common fractions for better readability
+  const FRACTIONS: Array<[number, string]> = [
+    [1 / 4, '1/4'],
+    [1 / 3, '1/3'],
+    [1 / 2, '1/2'],
+    [2 / 3, '2/3'],
+    [3 / 4, '3/4'],
+  ]
+  const TOLERANCE = 0.02
+  for (const [val, str] of FRACTIONS) {
+    if (Math.abs(n - val) <= TOLERANCE) return str
+  }
   if (Number.isInteger(n)) return n.toString()
   // Round to 1 decimal, remove trailing zero
   return n.toFixed(1).replace(/\.0$/, '')

--- a/lib/scaling.ts
+++ b/lib/scaling.ts
@@ -25,6 +25,33 @@ export function computePersonRatio(personKcal: number): number {
   return personKcal / BASE_KCAL_PER_PERSON
 }
 
+/**
+ * Zaokrągla wartość do najbliższego "ładnego" ułamka: 1/4, 1/3, 1/2, 2/3, 3/4 lub całości.
+ * Używane dla jednostek miarowych (łyżki, łyżeczki) gdzie precyzja jest ważna.
+ */
+export function snapToNiceFraction(value: number): number {
+  // Minimum 1/4 (mniej niż 1/4 to tyle co nic)
+  if (value < 0.15) return 0.25
+
+  const candidates: number[] = [0.25, 1 / 3, 0.5, 2 / 3, 0.75, 1, 1.25, 1 + 1 / 3, 1.5, 1 + 2 / 3, 1.75, 2]
+
+  if (value > 2) {
+    // Dla większych wartości zaokrąglaj do 0.5
+    return Math.round(value * 2) / 2
+  }
+
+  let best = candidates[0]
+  let bestDiff = Math.abs(value - candidates[0])
+  for (const c of candidates) {
+    const diff = Math.abs(value - c)
+    if (diff < bestDiff) {
+      bestDiff = diff
+      best = c
+    }
+  }
+  return best
+}
+
 export function scaleIngredient(ing: Ingredient, scaleFactor: number): Ingredient {
   const parsed = parseAmount(ing.amount)
   if (!parsed) return ing
@@ -34,17 +61,20 @@ export function scaleIngredient(ing: Ingredient, scaleFactor: number): Ingredien
   // zaokrąglenie: dla g/ml do 5, dla reszty 1 miejsce po przecinku lub pełne
   let rounded: number
   const unit = parsed.unit.toLowerCase()
+
+  // Jednostki, które mogą być wyrażane ułamkami (1/4, 1/3, 1/2, 2/3, 3/4)
+  const isSpoon = unit === 'łyżka' || unit === 'łyżki' || unit === 'łyżeczka' || unit === 'łyżeczki'
+
   const isDiscrete =
     ['ząbek', 'ząbki', 'puszka', 'puszki', 'szt', 'opakowanie', 'opakowania'].some((u) =>
       unit.includes(u)
-    ) ||
-    unit === 'łyżka' ||
-    unit === 'łyżki' ||
-    unit === 'łyżeczka' ||
-    unit === 'łyżeczki'
+    ) || isSpoon
 
   if (unit === 'g' || unit === 'ml') {
     rounded = Math.round(scaled / 5) * 5
+  } else if (isSpoon) {
+    // Dla łyżek i łyżeczek zaokrąglamy do ładnych ułamków: 1/4, 1/3, 1/2, 2/3, 3/4
+    rounded = snapToNiceFraction(scaled)
   } else if (isDiscrete) {
     // Dla jednostek "dyskretnych" (ząbki, puszki, sztuki) zaokrąglamy do 0.5 lub całości
     if (scaled < 1) {


### PR DESCRIPTION
## Summary

Adds support for displaying recipe amounts as proper fractions (1/4, 1/3, 1/2, 2/3, 3/4) instead of decimals (0.25, 0.33, 0.5, etc.), with particular focus on spoon units (łyżka, łyżeczka) where precision matters for spices and herbs.

## Changes

### `lib/amounts.ts`
- Updated `formatNumber()` to render common fractions as strings: `0.25 → "1/4"`, `0.33 → "1/3"`, `0.5 → "1/2"`, `0.67 → "2/3"`, `0.75 → "3/4"`

### `lib/scaling.ts`
- Added `snapToNiceFraction()` exported helper that rounds values to the nearest nice fraction from the set {1/4, 1/3, 1/2, 2/3, 3/4, 1, 1¼, 1⅓, 1½, 1⅔, 1¾, 2}
- Split discrete unit handling: spoon units (`łyżka`, `łyżeczka`) now use `snapToNiceFraction()` for fine-grained rounding, while other discrete units (puszka, ząbki, szt) keep existing 0.5-step rounding

### `__tests__/lib/scaling.test.ts`
- Added 8 tests for `snapToNiceFraction()` covering all fraction values and edge cases
- Added 5 integration tests for fraction scaling of spoon ingredients

## Test Results
All 144 tests pass (131 existing + 13 new).

Fixes giraffe-horizon/meal-swiper#10