### PR TITLE
fix: [UX] PWA / Instalacja na telefonie

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from 'next'
+import type { Metadata, Viewport } from 'next'
 import Script from 'next/script'
 import './globals.css'
 import AppShell from '@/components/AppShell'
@@ -6,6 +6,12 @@ import AppShell from '@/components/AppShell'
 export const metadata: Metadata = {
   title: 'Meal Swiper - Planowanie posiłków',
   description: 'Aplikacja do planowania posiłków na tydzień w stylu Tinder',
+  manifest: '/manifest.json',
+  appleWebApp: {
+    capable: true,
+    statusBarStyle: 'default',
+    title: 'Meal Swiper',
+  },
   robots: {
     index: false,
     follow: false,
@@ -13,11 +19,31 @@ export const metadata: Metadata = {
   },
 }
 
+export const viewport: Viewport = {
+  themeColor: '#10B981',
+}
+
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="pl">
       <body>
         <AppShell>{children}</AppShell>
+        <Script id="register-sw" strategy="afterInteractive">
+          {`
+            if ('serviceWorker' in navigator) {
+              window.addEventListener('load', function() {
+                navigator.serviceWorker.register('/sw.js').then(
+                  function(registration) {
+                    console.log('Service Worker registration successful with scope: ', registration.scope);
+                  },
+                  function(err) {
+                    console.log('Service Worker registration failed: ', err);
+                  }
+                );
+              });
+            }
+          `}
+        </Script>
         <Script
           src="https://static.cloudflareinsights.com/beacon.min.js"
           data-cf-beacon='{"token": "CLOUDFLARE_ANALYTICS_TOKEN"}'

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,24 @@
+{
+  "name": "Meal Swiper",
+  "short_name": "MealSwiper",
+  "description": "Aplikacja do planowania posiłków na tydzień",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#FAFAF8",
+  "theme_color": "#10B981",
+  "orientation": "portrait",
+  "icons": [
+    {
+      "src": "/icons/icon-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "any maskable"
+    },
+    {
+      "src": "/icons/icon-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "any maskable"
+    }
+  ]
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,0 +1,36 @@
+const CACHE_NAME = 'meal-swiper-v1';
+const ASSETS_TO_CACHE = [
+  '/',
+  '/manifest.json',
+  '/robots.txt'
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => {
+      return cache.addAll(ASSETS_TO_CACHE);
+    })
+  );
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((cacheNames) => {
+      return Promise.all(
+        cacheNames.filter((cacheName) => {
+          return cacheName !== CACHE_NAME;
+        }).map((cacheName) => {
+          return caches.delete(cacheName);
+        })
+      );
+    })
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  event.respondWith(
+    caches.match(event.request).then((response) => {
+      return response || fetch(event.request);
+    })
+  );
+});


### PR DESCRIPTION
## Summary

Adds PWA support including manifest.json, service worker, and meta tags.

## Changes

- Added `public/manifest.json` with PWA configuration
- Implemented a basic service worker in `public/sw.js` for caching
- Updated `app/layout.tsx` to include PWA meta tags and register the service worker
- Configured `themeColor` using the `viewport` export (Next.js 14+)

Note: Placeholder icon paths were added to the manifest. Real icons should be placed in `public/icons/`.

Fixes giraffe-horizon/meal-swiper#5