### PR TITLE
feat: [FEAT] Eksport listy zakupów do TickTick

### DIFF
--- a/.dev.vars.example
+++ b/.dev.vars.example
@@ -1,0 +1,10 @@
+# Copy to .dev.vars and fill in your values for local development.
+# These are Cloudflare Pages secrets (not committed to git).
+
+# Google Custom Search — image fallback for meals
+GOOGLE_CSE_API_KEY=
+GOOGLE_CSE_CX=
+
+# TickTick Open API OAuth2 access token — for shopping list export
+# Get it from https://developer.ticktick.com/manage
+TICKTICK_ACCESS_TOKEN=

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,8 @@ meal-swiper/
 │       ├── meals/route.ts           # GET — D1
 │       ├── plan/route.ts            # GET/POST — D1
 │       ├── shopping-checked/route.ts # GET/POST — D1
-│       └── image-search/route.ts    # Google CSE
+│       ├── image-search/route.ts    # Google CSE
+│       └── ticktick-export/route.ts # POST — eksport do TickTick
 ├── components/
 │   ├── AppShell.tsx         # Layout wrapper (header, nav, context)
 │   ├── Navigation.tsx       # Mobile bottom nav (4 tabs) + desktop sidebar
@@ -96,6 +97,7 @@ npm run deploy         # build + wrangler deploy
 
 - `GOOGLE_CSE_API_KEY` — Google Custom Search (image fallback)
 - `GOOGLE_CSE_CX` — Google Search Engine ID
+- `TICKTICK_ACCESS_TOKEN` — TickTick Open API OAuth2 access token (eksport listy zakupów)
 
 ## D1 — baza danych
 

--- a/__tests__/api/ticktick-export.test.ts
+++ b/__tests__/api/ticktick-export.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { POST } from '@/app/api/ticktick-export/route'
+import type { NextRequest } from 'next/server'
+
+function makeRequest(body: unknown): NextRequest {
+  return new Request('http://localhost/api/ticktick-export', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  }) as unknown as NextRequest
+}
+
+describe('POST /api/ticktick-export', () => {
+  beforeEach(() => {
+    vi.stubEnv('TICKTICK_ACCESS_TOKEN', '')
+    global.fetch = vi.fn()
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('returns 503 when TICKTICK_ACCESS_TOKEN is not configured', async () => {
+    const res = await POST(makeRequest({ items: [{ name: 'Makaron', amount: '200g' }] }))
+    expect(res.status).toBe(503)
+    const body = await res.json()
+    expect(body.error).toContain('TICKTICK_ACCESS_TOKEN')
+  })
+
+  it('returns 400 when items are missing', async () => {
+    vi.stubEnv('TICKTICK_ACCESS_TOKEN', 'test-token')
+    const res = await POST(makeRequest({}))
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 when items array is empty', async () => {
+    vi.stubEnv('TICKTICK_ACCESS_TOKEN', 'test-token')
+    const res = await POST(makeRequest({ items: [] }))
+    expect(res.status).toBe(400)
+  })
+
+  it('creates a TickTick project and adds tasks on success', async () => {
+    vi.stubEnv('TICKTICK_ACCESS_TOKEN', 'valid-token')
+    global.fetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ id: 'project-123' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ id2TaskMap: {} }),
+      })
+
+    const res = await POST(
+      makeRequest({
+        items: [
+          { name: 'Makaron', amount: '200g' },
+          { name: 'Jajka', amount: '3 szt' },
+        ],
+        weekLabel: '10-14.03',
+      })
+    )
+
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.ok).toBe(true)
+    expect(body.projectId).toBe('project-123')
+    expect(body.projectName).toBe('🛒 Zakupy 10-14.03')
+
+    // Verify TickTick API was called with correct payload
+    expect(global.fetch).toHaveBeenCalledTimes(2)
+    const [, batchCall] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls
+    const batchBody = JSON.parse(batchCall[1].body as string)
+    expect(batchBody.add).toHaveLength(2)
+    expect(batchBody.add[0].title).toBe('Makaron — 200g')
+    expect(batchBody.add[0].projectId).toBe('project-123')
+  })
+
+  it('returns 502 when TickTick API fails', async () => {
+    vi.stubEnv('TICKTICK_ACCESS_TOKEN', 'valid-token')
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: false,
+      status: 401,
+      text: async () => 'Unauthorized',
+    })
+
+    const res = await POST(makeRequest({ items: [{ name: 'Makaron', amount: '200g' }] }))
+
+    expect(res.status).toBe(502)
+  })
+})

--- a/__tests__/components/ShoppingListView.test.tsx
+++ b/__tests__/components/ShoppingListView.test.tsx
@@ -168,6 +168,73 @@ describe('ShoppingListView', () => {
     expect(writeText).toHaveBeenCalled()
   })
 
+  it('renders TickTick export button when items exist', async () => {
+    render(<ShoppingListView weeklyPlan={planWithMeal} weekOffset={0} />)
+
+    await waitFor(() => {
+      expect(screen.getByText(/Makaron/)).toBeInTheDocument()
+    })
+
+    expect(screen.getByText('TickTick')).toBeInTheDocument()
+  })
+
+  it('TickTick export button calls /api/ticktick-export and shows success alert', async () => {
+    window.alert = vi.fn()
+    global.fetch = vi.fn().mockImplementation((url: string) => {
+      if (String(url).includes('ticktick-export')) {
+        return Promise.resolve({ ok: true, json: async () => ({ ok: true }) })
+      }
+      return Promise.resolve({ ok: true, json: async () => null })
+    })
+
+    render(<ShoppingListView weeklyPlan={planWithMeal} weekOffset={0} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('TickTick')).toBeInTheDocument()
+    })
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('TickTick'))
+    })
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/ticktick-export',
+        expect.objectContaining({ method: 'POST' })
+      )
+      expect(window.alert).toHaveBeenCalledWith(expect.stringContaining('TickTick'))
+    })
+  })
+
+  it('TickTick export button shows error alert on API failure', async () => {
+    window.alert = vi.fn()
+    global.fetch = vi.fn().mockImplementation((url: string) => {
+      if (String(url).includes('ticktick-export')) {
+        return Promise.resolve({
+          ok: false,
+          status: 503,
+          statusText: 'Service Unavailable',
+          json: async () => ({ error: 'TickTick not configured' }),
+        })
+      }
+      return Promise.resolve({ ok: true, json: async () => null })
+    })
+
+    render(<ShoppingListView weeklyPlan={planWithMeal} weekOffset={0} />)
+
+    await waitFor(() => {
+      expect(screen.getByText('TickTick')).toBeInTheDocument()
+    })
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('TickTick'))
+    })
+
+    await waitFor(() => {
+      expect(window.alert).toHaveBeenCalledWith(expect.stringContaining('TickTick not configured'))
+    })
+  })
+
   it('reset list with confirm=true clears all items', async () => {
     window.confirm = vi.fn(() => true)
     const { removeCheckedItems } = await import('@/lib/storage')

--- a/app/api/ticktick-export/route.ts
+++ b/app/api/ticktick-export/route.ts
@@ -1,0 +1,96 @@
+import type { NextRequest } from 'next/server'
+
+const TICKTICK_API_BASE = 'https://api.ticktick.com/open/v1'
+
+export interface ShoppingExportItem {
+  name: string
+  amount: string
+}
+
+interface TickTickTask {
+  title: string
+  projectId: string
+  sortOrder?: number
+}
+
+async function createTickTickProject(token: string, name: string): Promise<string> {
+  const res = await fetch(`${TICKTICK_API_BASE}/project`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ name, color: '#4CAF50', viewMode: 'list', kind: 'TASK' }),
+  })
+  if (!res.ok) {
+    const body = await res.text()
+    throw new Error(`TickTick createProject failed (${res.status}): ${body}`)
+  }
+  const data = (await res.json()) as { id: string }
+  return data.id
+}
+
+async function addTasksBatch(
+  token: string,
+  projectId: string,
+  items: ShoppingExportItem[]
+): Promise<void> {
+  const tasks: TickTickTask[] = items.map((item, index) => ({
+    title: `${item.name} — ${item.amount}`,
+    projectId,
+    sortOrder: index,
+  }))
+
+  const res = await fetch(`${TICKTICK_API_BASE}/batch/task`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ add: tasks }),
+  })
+  if (!res.ok) {
+    const body = await res.text()
+    throw new Error(`TickTick addTasks failed (${res.status}): ${body}`)
+  }
+}
+
+export async function POST(request: NextRequest) {
+  const token = process.env.TICKTICK_ACCESS_TOKEN
+  if (!token) {
+    return Response.json(
+      { error: 'TickTick not configured — missing TICKTICK_ACCESS_TOKEN' },
+      { status: 503 }
+    )
+  }
+
+  let body: { items?: ShoppingExportItem[]; weekLabel?: string }
+  try {
+    body = await request.json()
+  } catch {
+    return Response.json({ error: 'Invalid JSON body' }, { status: 400 })
+  }
+
+  const { items, weekLabel } = body
+
+  if (!items || !Array.isArray(items) || items.length === 0) {
+    return Response.json(
+      { error: 'items array is required and must not be empty' },
+      { status: 400 }
+    )
+  }
+
+  const projectName = weekLabel ? `🛒 Zakupy ${weekLabel}` : '🛒 Zakupy'
+
+  try {
+    const projectId = await createTickTickProject(token, projectName)
+    await addTasksBatch(token, projectId, items)
+    return Response.json({ ok: true, projectId, projectName })
+  } catch (error) {
+    console.error('TickTick export error:', error)
+    return Response.json(
+      { error: error instanceof Error ? error.message : 'Failed to export to TickTick' },
+      { status: 502 }
+    )
+  }
+}

--- a/components/ShoppingListView.tsx
+++ b/components/ShoppingListView.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useMemo } from 'react'
 import type { WeeklyPlan } from '@/types'
-import { getWeekKey } from '@/lib/utils'
+import { getWeekKey, getWeekDates, formatWeekRangeShort } from '@/lib/utils'
 import { getCheckedItems, saveCheckedItems, removeCheckedItems } from '@/lib/storage'
 import { generateShoppingList } from '@/lib/shopping'
 import { useAppContext } from '@/lib/context'
@@ -93,6 +93,35 @@ export default function ShoppingListView({ weeklyPlan, weekOffset }: ShoppingLis
     alert('✅ Lista skopiowana do schowka!')
   }
 
+  const [tickTickExporting, setTickTickExporting] = useState(false)
+
+  const exportToTickTick = async () => {
+    if (tickTickExporting) return
+    setTickTickExporting(true)
+    try {
+      const weekDates = getWeekDates(weekOffset)
+      const weekLabel = formatWeekRangeShort(weekDates)
+      const res = await fetch('/api/ticktick-export', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          items: items.map((item) => ({ name: item.name, amount: item.amount })),
+          weekLabel,
+        }),
+      })
+      if (res.ok) {
+        alert('✅ Lista zakupów wyeksportowana do TickTick!')
+      } else {
+        const data = (await res.json()) as { error?: string }
+        alert(`❌ Błąd eksportu: ${data.error ?? res.statusText}`)
+      }
+    } catch {
+      alert('❌ Nie udało się połączyć z TickTick.')
+    } finally {
+      setTickTickExporting(false)
+    }
+  }
+
   return (
     <div className="flex flex-col flex-1 min-h-0 bg-background-light dark:bg-background-dark">
       {/* Toolbar */}
@@ -117,6 +146,16 @@ export default function ShoppingListView({ weeklyPlan, weekOffset }: ShoppingLis
             >
               <span className="material-symbols-outlined text-[16px]">share</span>
               Udostępnij
+            </button>
+            <button
+              onClick={exportToTickTick}
+              disabled={tickTickExporting}
+              className="text-xs font-medium text-primary hover:bg-primary/10 px-3 py-1.5 rounded-lg transition-colors flex items-center gap-1 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              <span className="material-symbols-outlined text-[16px]">
+                {tickTickExporting ? 'hourglass_empty' : 'checklist'}
+              </span>
+              {tickTickExporting ? 'Eksportuję…' : 'TickTick'}
             </button>
           </div>
         </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1879,7 +1879,6 @@
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.4.2.tgz",
       "integrity": "sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==",
-      "dev": true,
       "license": "MIT OR Apache-2.0",
       "engines": {
         "node": ">=18.0.0"
@@ -1889,7 +1888,6 @@
       "version": "2.15.0",
       "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.15.0.tgz",
       "integrity": "sha512-EGYmJaGZKWl+X8tXxcnx4v2bOZSjQeNI5dWFeXivgX9+YCT69AkzHHwlNbVpqtEUTbew8eQurpyOpeN8fg00nw==",
-      "dev": true,
       "license": "MIT OR Apache-2.0",
       "peerDependencies": {
         "unenv": "2.0.0-rc.24",
@@ -1908,7 +1906,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1925,7 +1922,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1942,7 +1938,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1959,7 +1954,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1976,7 +1970,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -2001,7 +1994,6 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
@@ -2014,7 +2006,6 @@
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
       "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
@@ -2205,18 +2196,6 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@dotenvx/dotenvx/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/@dotenvx/dotenvx/node_modules/which": {
@@ -3068,7 +3047,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
       "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -4699,7 +4677,7 @@
       "version": "1.58.2",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
       "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright": "1.58.2"
@@ -4760,7 +4738,6 @@
       "version": "4.1.6",
       "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
       "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "kleur": "^4.1.5"
@@ -4770,7 +4747,6 @@
       "version": "0.6.5",
       "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
       "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@poppinss/colors": "^4.1.5",
@@ -4782,7 +4758,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
       "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -4795,7 +4770,6 @@
       "version": "10.2.2",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
       "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -4808,7 +4782,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
       "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@rolldown/pluginutils": {
@@ -6578,7 +6551,6 @@
       "version": "1.2.14",
       "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.14.tgz",
       "integrity": "sha512-G4ewlBNhUtlLvrJTb88d2mdy2KRijzs4UhnlrOSRT4bmjh/IqNElZa3zkrZ+TC47TwtlDWzVLFADljF1Ijp5hA==",
-      "dev": true,
       "license": "CC0-1.0"
     },
     "node_modules/@standard-schema/spec": {
@@ -7759,6 +7731,19 @@
         "node": ">= 8"
       }
     },
+    "node_modules/anymatch/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/arg": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
@@ -8156,7 +8141,6 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/blake3-wasm/-/blake3-wasm-2.1.5.tgz",
       "integrity": "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/body-parser": {
@@ -9437,7 +9421,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -9834,7 +9817,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
       "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/antfu"
@@ -11397,7 +11379,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -12881,7 +12862,6 @@
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
       "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -13454,6 +13434,19 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -13515,7 +13508,6 @@
       "version": "4.20260310.0",
       "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260310.0.tgz",
       "integrity": "sha512-uC5vNPenFpDSj5aUU3wGSABG6UUqMr+Xs1m4AkCrTHo37F4Z6xcQw5BXqViTfPDVT/zcYH1UgTVoXhr1l6ZMXw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
@@ -16391,7 +16383,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -16401,13 +16392,12 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
       "engines": {
-        "node": ">=8.6"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
@@ -16514,7 +16504,7 @@
       "version": "1.58.2",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
       "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "playwright-core": "1.58.2"
@@ -16533,7 +16523,7 @@
       "version": "1.58.2",
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
       "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
@@ -16546,7 +16536,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -17079,6 +17068,19 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/readdirp/node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/redent": {
@@ -17760,7 +17762,6 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "devOptional": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -17964,7 +17965,6 @@
       "version": "0.34.5",
       "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
       "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
-      "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -18955,19 +18955,6 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
-    "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/tinyrainbow": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
@@ -19347,7 +19334,6 @@
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.18.2.tgz",
       "integrity": "sha512-y+8YjDFzWdQlSE9N5nzKMT3g4a5UBX1HKowfdXh0uvAnTaqqwqB92Jt4UXBAeKekDs5IaDKyJFR4X1gYVCgXcw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
@@ -19363,7 +19349,6 @@
       "version": "2.0.0-rc.24",
       "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
       "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pathe": "^2.0.3"
@@ -19628,19 +19613,6 @@
         }
       }
     },
-    "node_modules/vite/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/vitest": {
       "version": "4.0.18",
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
@@ -19734,19 +19706,6 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
-      }
-    },
-    "node_modules/vitest/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/vitest/node_modules/tinyexec": {
@@ -19963,7 +19922,6 @@
       "version": "1.20260310.1",
       "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260310.1.tgz",
       "integrity": "sha512-yawXhypXXHtArikJj15HOMknNGikpBbSg2ZDe6lddUbqZnJXuCVSkgc/0ArUeVMG1jbbGvpst+REFtKwILvRTQ==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "bin": {
@@ -19984,7 +19942,6 @@
       "version": "4.72.0",
       "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.72.0.tgz",
       "integrity": "sha512-bKkb8150JGzJZJWiNB2nu/33smVfawmfYiecA6rW4XH7xS23/jqMbgpdelM34W/7a1IhR66qeQGVqTRXROtAZg==",
-      "dev": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@cloudflare/kv-asset-handler": "0.4.2",
@@ -20019,7 +19976,6 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
       "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/wrappy": {
@@ -20032,7 +19988,6 @@
       "version": "8.18.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
       "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -20187,7 +20142,6 @@
       "version": "4.1.0-beta.10",
       "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
       "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@poppinss/colors": "^4.1.5",
@@ -20201,7 +20155,6 @@
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
       "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@poppinss/exception": "^1.2.2",
@@ -20212,7 +20165,7 @@
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"


### PR DESCRIPTION
## Summary

Dodaje integrację z TickTick: przycisk **"TickTick"** w toolbarze listy zakupów eksportuje wszystkie produkty do TickTick jako nowy projekt z zadaniami.

## Changes

- **`app/api/ticktick-export/route.ts`** — nowy endpoint API; tworzy projekt w TickTick i dodaje produkty jako zadania za pomocą `POST /open/v1/batch/task`. Wymaga zmiennej środowiskowej `TICKTICK_ACCESS_TOKEN` (TickTick Open API OAuth2 token).
- **`components/ShoppingListView.tsx`** — przycisk "TickTick" w toolbarze z obsługą stanu ładowania (`Eksportuję…`) oraz alertami sukcesu/błędu.
- **`__tests__/api/ticktick-export.test.ts`** — 5 testów jednostkowych dla nowego endpointu (brak tokena, puste items, sukces, błąd API).
- **`__tests__/components/ShoppingListView.test.tsx`** — 4 nowe testy: wyrenderowanie przycisku, alert sukcesu, alert błędu.
- **`.dev.vars.example`** — dokumentacja wymaganych zmiennych środowiskowych.
- **`CLAUDE.md`** — aktualizacja: nowy route i `TICKTICK_ACCESS_TOKEN`.

## Testing

Wszystkie 357 testów przechodzi. Przetestować manualnie po skonfigurowaniu `TICKTICK_ACCESS_TOKEN` jako Cloudflare Pages Secret.

## Setup

Aby aktywować funkcję, dodaj `TICKTICK_ACCESS_TOKEN` jako secret w Cloudflare Pages (token z https://developer.ticktick.com/manage).

Fixes giraffe-horizon/meal-swiper#8